### PR TITLE
Optimize the number of "View" queries sent to GeoProxy

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9874,6 +9874,11 @@
         "warning": "^4.0.3"
       }
     },
+    "react-leaflet-control": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet-control/-/react-leaflet-control-2.1.1.tgz",
+      "integrity": "sha512-3fx4uSRFtDaFNa1yq62DCxdc9kR3Lk4V7R0lHqbKfPTEIOvPR7VFvk3xzcSnSB/0LAYO8R96Pwcs1c6knyL/Hw=="
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "react-bootstrap": "^1.0.0-beta.13",
     "react-dom": "^16.9.0",
     "react-leaflet": "^2.4.0",
+    "react-leaflet-control": "^2.1.1",
     "react-scripts": "3.1.2",
     "segmented-control": "^0.1.12"
   },

--- a/client/src/MapView/MapView.js
+++ b/client/src/MapView/MapView.js
@@ -2,44 +2,59 @@ import React from 'react';
 import '../App.css';
 import { Map, TileLayer } from 'react-leaflet';
 import RequestHelper from '../RequestHelper';
+import Control from 'react-leaflet-control';
+import Button from 'react-bootstrap/Button';
+
 class MapView extends React.Component {
     constructor(props) {
         super(props);
         this.map = undefined;
+        this.state = {
+            currentZoom: 10
+        };
     }
     componentDidMount() {
 
-        this.map.leafletElement.on('moveend', () => {
-            if (this.props.mode === 'view') {
-                // console.log(this.map)
-                const southWestBounds = this.map.leafletElement.getBounds().getSouthWest().wrap();
-                const northEastBounds = this.map.leafletElement.getBounds().getNorthEast().wrap();
-                const upperLeft = [northEastBounds.lat, southWestBounds.lng].map(x => Number(x));
-                const bottomRight = [southWestBounds.lat, northEastBounds.lng].map(x => Number(x));
-
-                // console.log(upperLeft, bottomRight);
-                //  query view
-                RequestHelper.queryViewBoundingBox(upperLeft, bottomRight)
-                    .then(res => {
-                        console.log(res);
-                        //  TODO: update shared state so that Sidebar can display results
-                        //  TODO: update markers for display on map
-                    })
-                    .catch(err => console.log(err));
-            }
+        this.map.leafletElement.on('zoomend', () => {
+            this.setState({ currentZoom: this.map.leafletElement.getZoom() });
         });
     }
     handleClick(e) {
         this.props.updateLatLngFunc({ lat: e.latlng.lat, lng: e.latlng.lng });
     }
+    handleViewClick() {
+        const southWestBounds = this.map.leafletElement.getBounds().getSouthWest().wrap();
+        const northEastBounds = this.map.leafletElement.getBounds().getNorthEast().wrap();
+        const upperLeft = [northEastBounds.lat, southWestBounds.lng].map(x => Number(x));
+        const bottomRight = [southWestBounds.lat, northEastBounds.lng].map(x => Number(x));
+
+        console.log(upperLeft, bottomRight);
+        //  query view
+        RequestHelper.queryViewBoundingBox(upperLeft, bottomRight)
+            .then(res => {
+                console.log(res);
+                //  TODO: update shared state so that Sidebar can display results
+                //  TODO: update markers for display on map
+            })
+            .catch(err => console.log(err));
+    }
     render() {
+
         return (
             <Map ref={(ref) => { this.map = ref; }} onClick={this.handleClick.bind(this)} center={[29.749907, -95.358421]} zoom={10}
-                style={{ height: '100vh', width: '100%' }}>
+                style={{ height: '90vh', width: '100%' }}>
                 <TileLayer
                     attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
+
+                {this.props.mode === 'view' && this.state.currentZoom > 6 ?
+                    <Control position="topright" >
+                        <Button onClick={() => this.handleViewClick.bind(this)}>
+                            Query
+                        </Button>
+                    </Control>
+                    : null}
             </Map>
         );
     }

--- a/client/src/MapView/MapView.js
+++ b/client/src/MapView/MapView.js
@@ -11,10 +11,13 @@ class MapView extends React.Component {
 
         this.map.leafletElement.on('moveend', () => {
             if (this.props.mode === 'view') {
-                const bounds = this.map.leafletElement.getBounds();
-                const upperLeft = [bounds['_northEast'].lat, bounds['_southWest'].lng].map(x => Number(x));
-                const bottomRight = [bounds['_southWest'].lat, bounds['_northEast'].lng].map(x => Number(x));
+                // console.log(this.map)
+                const southWestBounds = this.map.leafletElement.getBounds().getSouthWest().wrap();
+                const northEastBounds = this.map.leafletElement.getBounds().getNorthEast().wrap();
+                const upperLeft = [northEastBounds.lat, southWestBounds.lng].map(x => Number(x));
+                const bottomRight = [southWestBounds.lat, northEastBounds.lng].map(x => Number(x));
 
+                // console.log(upperLeft, bottomRight);
                 //  query view
                 RequestHelper.queryViewBoundingBox(upperLeft, bottomRight)
                     .then(res => {

--- a/client/src/RequestHelper.js
+++ b/client/src/RequestHelper.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 const RequestHelper = {
     queryViewBoundingBox: (upperLeft, bottomRight) => {
-        return axios.post('', { latlng1: upperLeft, latlng2: bottomRight });
+        return axios.post('', JSON.stringify({ latlng1: upperLeft, latlng2: bottomRight }));
     },
     submitPlace: (text, coordinate) => {
         // {
@@ -9,7 +9,7 @@ const RequestHelper = {
         //     "coordinate": [-20, -20],
         //     "timestamp": "2019-10-05T11:22:52.000Z"
         // }
-        return axios.post('', { text, coordinate, timestamp: new Date() });
+        return axios.post('', JSON.stringify({ text, coordinate, timestamp: new Date() }));
     }
 }
 export default RequestHelper;


### PR DESCRIPTION
This change mostly implements #60 , with 2 minor additions:

1. GeoProxy expects a stringified payload without any headers.

2. Wrap the map bounds so that longitude is [-180, 180].

 @sxxgrc FYI since we spoke about this optimization over the weekend.