### PR TITLE
Testing Server Side Endpoints

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,9 +12,13 @@
     "pg": "^7.12.1",
     "uuid": "^3.3.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-http": "^2.0.1",
+    "mocha": "^2.5.3"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha --timeout 10000",
     "server": "node server.js"
   },
   "keywords": [],

--- a/server/server.js
+++ b/server/server.js
@@ -37,3 +37,5 @@ app.post('/test-middleware', validationMiddleware.validSubmitRequestProperties, 
 app.listen(port, () => {
     console.log(`App running on port ${port}.`);
 });
+
+module.exports = app;

--- a/server/test/checks.js
+++ b/server/test/checks.js
@@ -1,0 +1,33 @@
+// TODO: During the test the env variable is set to test
+// process.env.NODE_ENV = 'test';
+
+//Require the dev-dependencies
+let chai = require('chai');
+let chaiHttp = require('chai-http');
+let server = require('../server');
+let should = chai.should();
+
+chai.use(chaiHttp);
+
+describe('Stories', () => {
+  /*
+  * Test the /POST route
+  */
+  describe('/POST view', () => {
+      it('it should not POST a view without latlng2 field', (done) => {
+          let view = {
+            "latlng1": [20, 0],
+            // "latlng2": [0, 80]
+        }
+        chai.request(server)
+            .post('/view')
+            .send(view)
+            .end((err, res) => {
+                  res.should.have.status(200);
+                  res.body.should.have.property('errors');
+              done();
+            });
+      });
+
+  });
+});


### PR DESCRIPTION
Added a test for posting a view without the field latlng2. Right now the test is failing because we did not check if the field exists.

To run the test suites, `npm test`

#71 